### PR TITLE
feat: implement points and bingoes left till item

### DIFF
--- a/src/main/java/com/github/indigopolecat/bingobrewers/BingoBrewersConfig.java
+++ b/src/main/java/com/github/indigopolecat/bingobrewers/BingoBrewersConfig.java
@@ -41,5 +41,17 @@ public class BingoBrewersConfig extends Config {
     )
     public static boolean showCoinsPerBingoPoint = true;
 
+    @Switch(
+            name = "Display Missing Bingo Points",
+            category = "Misc",
+            description = "Display the amount of missing Bingo Points to buy the item."
+    )
+    public static boolean displayMissingBingoPoints = true;
 
+    @Switch(
+            name = "Display Missing Bingoes",
+            category = "Misc",
+            description = "Display how many Bingoes are required to buy the item."
+    )
+    public static boolean displayMissingBingoes = true;
 }

--- a/src/main/java/com/github/indigopolecat/bingobrewers/ChestInventories.java
+++ b/src/main/java/com/github/indigopolecat/bingobrewers/ChestInventories.java
@@ -310,13 +310,15 @@ public class ChestInventories {
         int itemCostInBingoPoints = item.getBingoPointsPrice();
         int pointsLeftToAffordItem = itemCostInBingoPoints - this.currentBingoPoints;
         int bingoesRequired = (int) Math.ceil((double) pointsLeftToAffordItem / POINTS_PER_BINGO);
+        int toolTipIndex = item.getCostIndex() + 2;
 
         if (pointsLeftToAffordItem > 0 && BingoBrewersConfig.displayMissingBingoPoints) {
-            event.toolTip.add("§6Points left to afford item: " + pointsLeftToAffordItem);
+            event.toolTip.add(toolTipIndex,"§6Points left to afford item: " + pointsLeftToAffordItem);
+            toolTipIndex++;
         }
 
         if (bingoesRequired > 0 && BingoBrewersConfig.displayMissingBingoes) {
-            event.toolTip.add("§Completed Bingoes required: " + bingoesRequired);
+            event.toolTip.add(toolTipIndex,"§6Completed Bingoes required: " + bingoesRequired);
         }
     }
 

--- a/src/main/java/com/github/indigopolecat/bingobrewers/ChestInventories.java
+++ b/src/main/java/com/github/indigopolecat/bingobrewers/ChestInventories.java
@@ -20,7 +20,7 @@ import net.minecraft.nbt.NBTTagList;
 import java.text.DecimalFormat;
 
 public class ChestInventories {
-    public static final int POINTS_PER_BINGO = 100;
+    public static final int POINTS_PER_BINGO = 85;
     boolean bingoShopOpen = false;
     boolean calculationsReady = false;
     ContainerChest containerChest;

--- a/src/main/java/com/github/indigopolecat/bingobrewers/ChestInventories.java
+++ b/src/main/java/com/github/indigopolecat/bingobrewers/ChestInventories.java
@@ -316,7 +316,7 @@ public class ChestInventories {
         }
 
         if (bingoesRequired > 0 && BingoBrewersConfig.displayMissingBingoes) {
-            event.toolTip.add("§6Bingoes required: " + bingoesRequired);
+            event.toolTip.add("§Completed Bingoes required: " + bingoesRequired);
         }
     }
 

--- a/src/main/java/com/github/indigopolecat/bingobrewers/TooltipInfo.java
+++ b/src/main/java/com/github/indigopolecat/bingobrewers/TooltipInfo.java
@@ -1,19 +1,22 @@
 package com.github.indigopolecat.bingobrewers;
 
 public class TooltipInfo {
-    // Contains all of the necessary information to add tooltip to bingo shop items
+    // Contains all the necessary information to add tooltip to bingo shop items
     private final String name;
     private final String costPerPoint;
     private final String extraCost;
     private final int extraCostIndex;
     private final int costIndex;
 
-    public TooltipInfo(String name, String cost, String extraCost, int costIndex, int extraCostIndex) {
+    private final int bingoPointsPrice;
+
+    public TooltipInfo(String name, String cost, String extraCost, int costIndex, int extraCostIndex, int bingoPointsPrice) {
         this.name = name;
         this.costPerPoint = cost;
         this.extraCost = extraCost;
         this.costIndex = costIndex;
         this.extraCostIndex = extraCostIndex;
+        this.bingoPointsPrice = bingoPointsPrice;
     }
 
     public String getName() {
@@ -34,5 +37,9 @@ public class TooltipInfo {
 
     public int getCostIndex() {
         return costIndex;
+    }
+
+    public int getBingoPointsPrice() {
+        return bingoPointsPrice;
     }
 }

--- a/src/main/java/com/github/indigopolecat/bingobrewers/TooltipInfo.java
+++ b/src/main/java/com/github/indigopolecat/bingobrewers/TooltipInfo.java
@@ -7,9 +7,18 @@ public class TooltipInfo {
     private final String extraCost;
     private final int extraCostIndex;
     private final int costIndex;
-
     private final int bingoPointsPrice;
 
+    /**
+     * Constructs a TooltipInfo object with the given parameters.
+     *
+     * @param name The name of the item.
+     * @param cost The cost per point of the item.
+     * @param extraCost The extra cost associated with the item, if any.
+     * @param costIndex The index in the tooltip where the cost per point should be inserted.
+     * @param extraCostIndex The index in the tooltip where the extra cost should be inserted.
+     * @param bingoPointsPrice The price of the item in Bingo Points.
+     */
     public TooltipInfo(String name, String cost, String extraCost, int costIndex, int extraCostIndex, int bingoPointsPrice) {
         this.name = name;
         this.costPerPoint = cost;


### PR DESCRIPTION
Changelog:

- add points left to afford item 
- add amount of bingoes left to afford item
- add setting options for points left to afford item 
- add setting options for amount of bingoes left to afford item


Comments before merging:

- I have over 1300 Bingo Points and could not fully test the feature. There is the chance that i messed sth up.
- I have set the `POINTS_PER_BINGO` for the calculation to 85. This is the "default" amount without community tasks. We maybe want to adjust this value