### PR TITLE
Update Github Actions and add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,21 +1,22 @@
 name: Run Gradle Build
-on: [push, pull_request]
+on: [ push, pull_request ]
+
 jobs:
   gradle:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         name: Setup Java
         with:
           distribution: temurin
           java-version: 17
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
       - name: Execute Gradle build
         run: ./gradlew build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         name: Upload built mod JAR
         with:
           name: mod-jar

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,10 +1,10 @@
-name: "Validate Gradle Wrapper"
-on: [push, pull_request]
+name: Validate Gradle Wrapper
+on: [ push, pull_request ]
 
 jobs:
   validation:
-    name: "Validation"
+    name: Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v2


### PR DESCRIPTION
Hey,
I'm excited for the cristal hollows crowdsource feature so I was browsing through the repo quickly and noticed that the Github Actions are not up to date so I bumped them and created added a dependabot config so that dependabot opens a PR when there's an update (you can check my fork, I did 2 commits to be sure it worked and yeah dependabot opened PRs).
For dependabot to work you may need to enable it in the settings of the repository -> Code security & analysis -> Dependabot version updates.
I also removed some unnecessary string quotes and formatted the action files.
Hope to have the crowdsourced loot feature next bingo!